### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -16,6 +16,7 @@ module.exports = function ObjectMerge( obj, ...patches )
             (
                 typeof obj[key] === 'object' && typeof data[key] === 'object' && 
                 obj[key] !== null && obj[key] !== undefined && 
+                !isPrototypePolluted(key) && 
                 !Array.isArray( obj[key] ) && !Array.isArray( data[key] )
             )
             {
@@ -29,4 +30,8 @@ module.exports = function ObjectMerge( obj, ...patches )
     }
 
     return obj;
+}
+
+function isPrototypePolluted(key) {
+    return ['__proto__', 'constructor', 'prototype'].includes(key);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -59,4 +59,9 @@ describe( 'Tests', () =>
             'Didn`t merge objects properly'
         );
     });
+    
+    it('should not pollute prototype', () => {
+        ObjectMerge({}, JSON.parse('{"__proto__": {"polluted": true}}'));
+        assert.equal({}.polluted, undefined);
+    });
 });


### PR DESCRIPTION
### :bar_chart: Metadata *

`@liqd-js/alg-object-merge` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40liqd-js%2Falg-object-merge

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var algObjectMerge = require("@liqd-js/alg-object-merge")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
algObjectMerge(obj, payload);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i @liqd-js/alg-object-merge # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![alg-object-merge-fix](https://user-images.githubusercontent.com/43996156/102888665-3ecba180-447f-11eb-8894-61bc52af3fbd.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
